### PR TITLE
compat: use jest spyOn instead of jasmine global

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ It is common to want to use the `.promise()` method returned by most AWS client 
 
 ```ts
 it('should call the list method and return the Content keys', async () => {
-  const listSpy = createAwsServicePromisableSpy(
+  const listSpy: jest.SpyInstance = createAwsServicePromisableSpy(
     s3, // the mocked object to spy on
     'listObjectsV2', // the method to spy on
     'resolve', // 'resolve' or 'reject'

--- a/src/testing/aws-service-mocks.ts
+++ b/src/testing/aws-service-mocks.ts
@@ -37,7 +37,7 @@ export function createAwsServicePromisableSpy<T, K>(
   response: 'reject' | 'resolve',
   result?: K,
 ) {
-  return spyOn(object, method).and.returnValue(
+  return jest.spyOn(object, method).mockReturnValue(
     createAwsServicePromisableFunction(response, result),
   );
 }


### PR DESCRIPTION
Utilizing global jasmine methods may break apps without jasmine installed or without jasmine globals configured